### PR TITLE
Improvement to #1088. Returns None instead of 0 when no build number …

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -450,7 +450,15 @@ class MetaData(object):
         return res
 
     def build_number(self):
-        return int(self.get_value('build/number', 0))
+        number = self.get_value('build/number', 0)
+
+        # build number can come back as None if no setting (or jinja intermediate)
+        try:
+            build_int = int(number)
+        except (ValueError, TypeError):
+            # todo specialize
+            raise Exception('Build number was invalid value "{}". Must be an integer.'.format(number))
+        return build_int
 
     def ms_depends(self, typ='run'):
         res = []


### PR DESCRIPTION
Improvement to #1088. Returns None instead of 0 when no build number provided to trigger Jinja2 debugging help. Alerts users when invalid string like 'abc' passed instead of integer build number.
