### PR TITLE
Another dirty-related fix

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -107,8 +107,10 @@ def get_upstream_pins(m, dependencies, index):
     """Download packages from specs, then inspect each downloaded package for additional
     downstream dependency specs.  Return these additional specs."""
     dependencies = [strip_channel(dep) for dep in dependencies]
-    actions = environ.get_install_actions(m.config.build_prefix, index, dependencies,
-                                            m.config)
+    # Add _tmp here to prevent creating the build_prefix too early. This is because, when
+    # dirty is set, we skip calling create_env if the folder already exists.
+    actions = environ.get_install_actions(m.config.build_prefix+"_tmp", index, dependencies,
+                                          m.config)
     additional_specs = []
     linked_packages = actions['LINK']
     # edit the plan to download all necessary packages


### PR DESCRIPTION
Without this, conda creates `conda-meta/history` inside `build_prefix` even
on the first build attempt, so passing `--dirty` in that case means that we
do not get a populated `build_prefix` because if this folder already exists
`create_env()` gets skipped.