### PR TITLE
Added utility function that removes pycache directory created by pip

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -863,6 +863,7 @@ def bundle_conda(output, metadata, config, env, **kw):
     with utils.path_prepended(metadata.config.build_prefix):
         env = environ.get_dict(config=metadata.config, m=metadata)
     files = output.get('files', [])
+
     if not files and output.get('script'):
         interpreter = output.get('script_interpreter')
         if not interpreter:
@@ -1080,6 +1081,7 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
 
         utils.rm_rf(config.info_dir)
         files1 = prefix_files(prefix=config.build_prefix)
+
         for pat in m.always_include_files():
             has_matches = False
             for f in set(files1):
@@ -1141,6 +1143,7 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
                         cmd = [shell_path, '-x', '-e', work_file]
                         # this should raise if any problems occur while building
                         utils.check_call_env(cmd, env=env, cwd=src_dir)
+                        utils.remove_pycache_from_scripts(m.config.build_prefix)
 
     if post in [True, None]:
         with open(join(m.config.build_folder, 'prefix_files.txt'), 'r') as f:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -760,3 +760,16 @@ def conda_43():
     """Conda 4.3 broke compatibility in lots of new fun and exciting ways.  This function is for
     changing conda-build's behavior when conda 4.3 or higher is installed."""
     return LooseVersion(conda_version) >= LooseVersion('4.3')
+
+
+def remove_pycache_from_scripts(build_prefix):
+    """Remove pip created pycache directory from bin or Scripts."""
+    if on_win:
+        scripts_path = os.path.join(build_prefix, 'Scripts')
+    else:
+        scripts_path = os.path.join(build_prefix, 'bin')
+
+    for entry in os.listdir(scripts_path):
+        entry_path = os.path.join(scripts_path, entry)
+        if os.path.isdir(entry_path) and entry.strip(os.sep) == '__pycache__':
+            shutil.rmtree(entry_path)


### PR DESCRIPTION
``pip`` in the conda-build script creates a ``__pycache__`` folder in the build prefix's ``bin`` or ``Scripts`` directory. This utility function removes the ``__pycache__`` directory after its creation.